### PR TITLE
Fix issue with not correctly cleaning up disconnected connections

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1,0 +1,97 @@
+package epoller
+
+import (
+	"net"
+	"time"
+)
+
+func netConnToConn(in net.Conn) net.Conn {
+	if _, ok := in.(connImpl); ok {
+		return in
+	}
+
+	return connImpl{
+		conn: in,
+		fd:   socketFD(in),
+	}
+}
+
+type connImpl struct {
+	conn net.Conn
+	fd   int
+}
+
+// Read reads data from the connection.
+// Read can be made to time out and return an error after a fixed
+// time limit; see SetDeadline and SetReadDeadline.
+func (c connImpl) Read(b []byte) (n int, err error) {
+	return c.conn.Read(b)
+}
+
+// Write writes data to the connection.
+// Write can be made to time out and return an error after a fixed
+// time limit; see SetDeadline and SetWriteDeadline.
+func (c connImpl) Write(b []byte) (n int, err error) {
+	return c.conn.Write(b)
+}
+
+// Close closes the connection.
+// Any blocked Read or Write operations will be unblocked and return errors.
+func (c connImpl) Close() error {
+	return c.conn.Close()
+}
+
+// LocalAddr returns the local network address, if known.
+func (c connImpl) LocalAddr() net.Addr {
+	return c.conn.LocalAddr()
+}
+
+// RemoteAddr returns the remote network address, if known.
+func (c connImpl) RemoteAddr() net.Addr {
+	return c.conn.RemoteAddr()
+}
+
+// SetDeadline sets the read and write deadlines associated
+// with the connection. It is equivalent to calling both
+// SetReadDeadline and SetWriteDeadline.
+//
+// A deadline is an absolute time after which I/O operations
+// fail instead of blocking. The deadline applies to all future
+// and pending I/O, not just the immediately following call to
+// Read or Write. After a deadline has been exceeded, the
+// connection can be refreshed by setting a deadline in the future.
+//
+// If the deadline is exceeded a call to Read or Write or to other
+// I/O methods will return an error that wraps os.ErrDeadlineExceeded.
+// This can be tested using errors.Is(err, os.ErrDeadlineExceeded).
+// The error's Timeout method will return true, but note that there
+// are other possible errors for which the Timeout method will
+// return true even if the deadline has not been exceeded.
+//
+// An idle timeout can be implemented by repeatedly extending
+// the deadline after successful Read or Write calls.
+//
+// A zero value for t means I/O operations will not time out.
+func (c connImpl) SetDeadline(t time.Time) error {
+	return c.conn.SetDeadline(t)
+}
+
+// SetReadDeadline sets the deadline for future Read calls
+// and any currently-blocked Read call.
+// A zero value for t means Read will not time out.
+func (c connImpl) SetReadDeadline(t time.Time) error {
+	return c.conn.SetReadDeadline(t)
+}
+
+// SetWriteDeadline sets the deadline for future Write calls
+// and any currently-blocked Write call.
+// Even if write times out, it may return n > 0, indicating that
+// some of the data was successfully written.
+// A zero value for t means Write will not time out.
+func (c connImpl) SetWriteDeadline(t time.Time) error {
+	return c.conn.SetWriteDeadline(t)
+}
+
+func (c connImpl) GetFD() int {
+	return c.fd
+}

--- a/epoll.go
+++ b/epoll.go
@@ -25,6 +25,8 @@ func socketFD(conn net.Conn) int {
 			sfd = int(fd)
 		})
 		return sfd
+	} else if con, ok := conn.(connImpl); ok {
+		return con.fd
 	}
 	return 0
 }


### PR DESCRIPTION
If the client didn't cleanly close the connection, the module didn't correctly remove the connection from the internal map (because it couldn't access the fd on the closed socket object).  This fix saves the fd external to the connection, so it can be accessed post connection destruction.